### PR TITLE
Update plugin for Guard 2.x

### DIFF
--- a/guard-remote-sync.gemspec
+++ b/guard-remote-sync.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project = "guard-remote-synch"
 
-  s.add_dependency "guard", ">= 1.5.3"
+  s.add_dependency "guard", ">= 2.0.0"
 
   s.add_development_dependency 'bundler', '~> 1.0'
   s.add_development_dependency 'rake'

--- a/lib/guard/remote-sync.rb
+++ b/lib/guard/remote-sync.rb
@@ -1,8 +1,8 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 
 module Guard
-  class RemoteSync < Guard
+  class RemoteSync < Plugin
 
     autoload :Command, 'guard/remote-sync/command'
     autoload :Source, 'guard/remote-sync/source'
@@ -12,7 +12,7 @@ module Guard
     # Initialize a Guard.
     # @param [Array<Guard::Watcher>] watchers the Guard file watchers
     # @param [Hash] options the custom Guard options
-    def initialize(watchers = [], options = {})
+    def initialize(options = {})
       super
       @options = {
           :source => nil,

--- a/lib/guard/remote-sync/version.rb
+++ b/lib/guard/remote-sync/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module RemoteSyncVersion
-      VERSION = "0.0.7"
+      VERSION = "0.0.8"
   end
 end


### PR DESCRIPTION
Guard 2.x changes a few things, and if you upgrade guard to a late enough version, this plugin ceases to work.  This updates the plugin to work with Guard 2.x based on [this page](https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#guardguard-deprecated-in-favor-of-guardplugin).