### PR TITLE
update for compatibility with guard 2.12.x

### DIFF
--- a/guard-remote-sync.gemspec
+++ b/guard-remote-sync.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project = "guard-remote-synch"
 
-  s.add_dependency "guard", ">= 1.5.3"
+  s.add_dependency "guard", "~> 2.12.4"
+  s.add_dependency('guard-compat', '~> 1.0')
 
   s.add_development_dependency 'bundler', '~> 1.0'
   s.add_development_dependency 'rake'

--- a/lib/guard/remote-sync.rb
+++ b/lib/guard/remote-sync.rb
@@ -1,8 +1,8 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 
 module Guard
-  class RemoteSync < Guard
+  class RemoteSync < Plugin
 
     autoload :Command, 'guard/remote-sync/command'
     autoload :Source, 'guard/remote-sync/source'
@@ -10,9 +10,8 @@ module Guard
     attr_accessor :command
 
     # Initialize a Guard.
-    # @param [Array<Guard::Watcher>] watchers the Guard file watchers
     # @param [Hash] options the custom Guard options
-    def initialize(watchers = [], options = {})
+    def initialize(options = {})
       super
       @options = {
           :source => nil,
@@ -49,8 +48,8 @@ module Guard
     # @raise [:task_has_failed] when start has failed
     def start
       throw([:task_has_failed], "Guard::RemoteSync options invalid") unless options_valid?
-      UI.info "Guard::RemoteSync started in source directory '#{File.expand_path @source.directory}'"
-      Notifier.notify("Guard::RemoteSync is running in directory #{File.expand_path @source.directory}", notifier_options)
+      Guard::Compat::UI.info "Guard::RemoteSync started in source directory '#{File.expand_path @source.directory}'"
+      Guard::Compat::UI.notify("Guard::RemoteSync is running in directory #{File.expand_path @source.directory}", notifier_options)
       if @command.test
         @command.sync if options[:sync_on_start]
       else
@@ -63,15 +62,15 @@ module Guard
     # @raise [:task_has_failed] when stop has failed
 
     def stop
-      UI.info "Guard::RemoteSync stopped."
-      Notifier.notify("Guard::RemoteSync stopped.",notifier_options)
+      Guard::Compat::UI.info "Guard::RemoteSync stopped."
+      Guard::Compat::UI.notify("Guard::RemoteSync stopped.",notifier_options)
     end
 
     # Called when `reload|r|z + enter` is pressed.
     # This method should be mainly used for "reload" (really!) actions like reloading passenger/spork/bundler/...
     # @raise [:task_has_failed] when reload has failed
     def reload
-      Notifier.notify("Manual Guard::RemoteSync synchronize  #{File.expand_path @source.directory} to #{@destination.directory}",notifier_options)
+      Guard::Compat::UI.notify("Manual Guard::RemoteSync synchronize  #{File.expand_path @source.directory} to #{@destination.directory}",notifier_options)
       @command.sync
     end
 
@@ -79,7 +78,7 @@ module Guard
     # This method should be principally used for long action like running all specs/tests/...
     # @raise [:task_has_failed] when run_all has failed
     def run_all
-      Notifier.notify("Manual Guard::RemoteSync synchronize  #{@source.directory} to #{@destination.directory}",notifier_options)
+      Guard::Compat::UI.notify("Manual Guard::RemoteSync synchronize  #{@source.directory} to #{@destination.directory}",notifier_options)
       @command.sync
     end
 
@@ -87,7 +86,7 @@ module Guard
     # @param [Array<String>] paths the changes files or paths
     # @raise [:task_has_failed] when run_on_change has failed
     def run_on_changes(paths)
-      #paths.each do |p| ::Guard::UI.info("Files effect : #{p}")  end
+      #paths.each do |p| ::Guard::Guard::Compat::UI.info("Files effect : #{p}")  end
       @command.sync
     end
 
@@ -110,11 +109,11 @@ module Guard
     def options_valid?
       valid = true
       if options[:source].nil? && options[:cli_options].nil?
-        UI.error("Guard::RemoteSync a source directory is required")
+        Guard::Compat::UI.error("Guard::RemoteSync a source directory is required")
         valid = false
       end
       if options[:destination].nil? && options[:cli_options].nil?
-        UI.error("Guard::RemoteSync a source directory is required")
+        Guard::Compat::UI.error("Guard::RemoteSync a source directory is required")
         valid = false
       end
       valid

--- a/lib/guard/remote-sync/command.rb
+++ b/lib/guard/remote-sync/command.rb
@@ -34,7 +34,7 @@ module Guard
       end
 
       def sync
-        UI.info "Guard::RemoteSync `#{@command}`"
+        Compat::UI.info "Guard::RemoteSync `#{@command}`"
         run_command @command
       end
 
@@ -76,10 +76,10 @@ module Guard
 
       def build_command
         unless @options[:cli_options].nil?
-          UI.debug "Guard::RemoteSync ':cli' option was given so ignoring all other options, and outputting as is..." if @options[:verbose]
+          Compat::UI.debug "Guard::RemoteSync ':cli' option was given so ignoring all other options, and outputting as is..." if @options[:verbose]
           command = "#{rsync_command} #{@options[:cli_options]}"
         else
-          UI.debug "Guard::RemoteSync building rsync options from specified options" if @options[:verbose]
+          Compat::UI.debug "Guard::RemoteSync building rsync options from specified options" if @options[:verbose]
           @command_options = build_options
           @remote_options = check_remote_options
           @ssh_options = check_ssh_options

--- a/lib/guard/remote-sync/version.rb
+++ b/lib/guard/remote-sync/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module RemoteSyncVersion
-      VERSION = "0.0.7"
+      VERSION = "0.0.8"
   end
 end

--- a/spec/guard/remote-sync_spec.rb
+++ b/spec/guard/remote-sync_spec.rb
@@ -4,7 +4,7 @@ describe Guard::RemoteSync do
 
   before(:each) do
     File.stub!(:directory?).and_return(true)
-    ::Guard::UI.stub!(:info)
+    ::Guard::Compat::UI.stub!(:info)
   end
 
   describe "#initialize" do
@@ -15,9 +15,9 @@ describe Guard::RemoteSync do
 
     context "when no :source option is given" do
       it "should send an error notification and stop" do
-        ::Guard::UI.should_receive(:error)
+        ::Guard::Compat::UI.should_receive(:error)
         expect {
-          guard = described_class.new(nil, {:destination => "."})
+          guard = described_class.new({:destination => "."})
           guard.start
         }.to raise_exception
       end
@@ -25,9 +25,9 @@ describe Guard::RemoteSync do
 
     context "when no :destination option is given" do
       it "should send an error notification and stop" do
-        ::Guard::UI.should_receive(:error)
+        ::Guard::Compat::UI.should_receive(:error)
         expect {
-          guard = described_class.new(nil, {:source => "."})
+          guard = described_class.new({:source => "."})
           guard.start
         }.to raise_exception
       end
@@ -35,9 +35,9 @@ describe Guard::RemoteSync do
 
     context "when no :source and no :destination options are given" do
       it "should send 2 error notification and stop" do
-        ::Guard::UI.should_receive(:error).at_least 2
+        ::Guard::Compat::UI.should_receive(:error).at_least 2
         expect {
-          guard = described_class.new(nil, {})
+          guard = described_class.new({})
           guard.start
         }.to raise_exception
       end
@@ -51,19 +51,19 @@ describe Guard::RemoteSync do
       let(:destination) do
         "/remote/destination"
       end
-      it "should call the UI::info with the following message" do
+      it "should call the Compat::UI::info with the following message" do
         File.stub!(:expand_path).and_return(source)
-        Guard::Notifier.turn_off
-        ::Guard::UI.should_receive(:debug).with("Guard::RemoteSync building rsync options from specified options")
-        ::Guard::UI.should_receive(:info).with("Guard::RemoteSync started in source directory '#{source}'")
-        guard = described_class.new(nil, {:source => source, :destination => destination})
+        # ::Guard::UI.turn_off
+        ::Guard::Compat::UI.should_receive(:debug).with("Guard::RemoteSync building rsync options from specified options")
+        ::Guard::Compat::UI.should_receive(:info).with("Guard::RemoteSync started in source directory '#{source}'")
+        guard = described_class.new({:source => source, :destination => destination})
         guard.command.stub!(:test).and_return(true)
         guard.command.stub!(:sync).and_return(true)
         guard.start
       end
 
       it "should call command#sync on the system when :sync_on_start is true and command#test is true" do
-        guard = described_class.new(nil, {:source => source, :destination => destination, :sync_on_start => true})
+        guard = described_class.new({:source => source, :destination => destination, :sync_on_start => true})
         guard.command.stub!(:test).and_return(true)
         guard.command.should_receive(:sync).once
         guard.start
@@ -74,14 +74,14 @@ describe Guard::RemoteSync do
   describe "guard methods that get called when files change or the guard stops" do
 
     let(:guard) do
-      described_class.new(nil, {:source => "./source", :destination => "./destination"})
+      described_class.new({:source => "./source", :destination => "./destination"})
     end
 
     describe "#stop" do
       context "when the guard is stopped" do
         it "should output the following message" do
-          ::Guard::UI.should_receive(:debug).with("Guard::RemoteSync building rsync options from specified options")
-          ::Guard::UI.should_receive(:info).with("Guard::RemoteSync stopped.")
+          ::Guard::Compat::UI.should_receive(:debug).with("Guard::RemoteSync building rsync options from specified options")
+          ::Guard::Compat::UI.should_receive(:info).with("Guard::RemoteSync stopped.")
           guard.stop
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'rspec'
 require 'guard/remote-sync'
 require 'guard/remote-sync/command'
 require 'guard/remote-sync/source'
-
+require 'guard/compat/test/helper'
 include RSpec::Matchers
 
 RSpec.configure do |config|


### PR DESCRIPTION
This set of changes makes the plugin compatible with newest version of Guard. There has been couple of [deprecated features](https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0) in new Guard as well as [couple accidental changes](https://github.com/guard/guard/issues/692) that caused backward incompatibility.